### PR TITLE
fix: Pull upstream change to ignore UDR URI cache

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,9 +14,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/pcf.git
     source-type: git
-    source-commit: bcbdeb0c9f21f7334ab915114f5895ab6c289009
+    source-commit: 2dc89ef6bdb4357514ccb1853dfddacf3b852578
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:


### PR DESCRIPTION
# Description

Pull upstream change to ignore UDR URI cache, preventing failure of the PCF when the UDR crashes and changes IP.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
