### PR TITLE
chore: Update tag version from 1.4.0 to 1.4.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@
 
 ```bash
 rockcraft pack -v
-sudo skopeo --insecure-policy copy oci-archive:sdcore-pcf_1.4.0_amd64.rock docker-daemon:sdcore-pcf:1.4.0
-docker run sdcore-pcf:1.4.0
+sudo skopeo --insecure-policy copy oci-archive:sdcore-pcf_1.4.1_amd64.rock docker-daemon:sdcore-pcf:1.4.1
+docker run sdcore-pcf:1.4.1
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Container image for SD-Core PCF.
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/sdcore-pcf:1.4.0
-docker run -it ghcr.io/canonical/sdcore-pcf:1.4.0
+docker pull ghcr.io/canonical/sdcore-pcf:1.4.1
+docker run -it ghcr.io/canonical/sdcore-pcf:1.4.1
 ```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: sdcore-pcf
 base: bare
 build-base: ubuntu@22.04
-version: '1.4.0'
+version: '1.4.1'
 summary: SD-Core PCF
 description: SD-Core PCF
 license: Apache-2.0
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/pcf.git
     source-type: git
-    source-tag: v1.4.0
+    source-tag: v1.4.1
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

We need to update the Upstream project tag version to get the Webui URL customization patch as  it is available with  version 1.4.1.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
